### PR TITLE
Bumped Up libsignal_protocol_dart version to ^0.7.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  libsignal_protocol_dart: ^0.6.5
+  libsignal_protocol_dart: ^0.7.1
   collection: ^1.16.0
 
 dev_dependencies:


### PR DESCRIPTION
Bumped Up libsignal_protocol_dart version to ^0.7.1 in pubspec.yaml